### PR TITLE
feat: Fuseki Jena 6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - uses: go-task/setup-task@v1
+
+      - name: Run smoke test
+        run: task fuseki:smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: go-task/setup-task@v1
 
       - name: Run smoke test
-        run: task fuseki:smoke
+        run: task fuseki:smoke:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: go-task/setup-task@v1
 
       - name: Run smoke test
-        run: task fuseki:smoke
+        run: task fuseki:smoke:ci
 
       - name: Docker metadata
         id: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
         id: version
         run: echo "VALUE=$(npx --yes semver ${{ github.event.release.tag_name }})" >> "$GITHUB_OUTPUT"
 
+      - uses: go-task/setup-task@v1
+
+      - name: Run smoke test
+        run: task fuseki:smoke
+
       - name: Docker metadata
         id: metadata
         uses: docker/metadata-action@v5

--- a/README.md
+++ b/README.md
@@ -275,6 +275,28 @@ See [Taskfile.yml](Taskfile.yml) for local development commands.
 We can build patches for Jena ourselves by developing on a specific version of the Jena source code, and including patches in `/docker/patches`.
 A simple example of this is the addition of the GeoSPARQL dependency in `/docker/patches/enable-geosparql.diff` as inspired by the zazuko docker image.
 
-The process to add these to our own jena deployment is to check out the current Jena version tag from https://github.com/apache/jena , e.g. using `git checkout jena-6.0.0`
+### Upgrading to a new upstream Jena version
 
-Then make the necessary changes, and run `git diff > my-patch.diff` and add `my-patch.diff` to `/docker/patches` and in the `Dockerfile`.
+For this repository's current setup, the only required change for a normal upstream bump is:
+
+- update `ARG JENA_VERSION=...` in `docker/Dockerfile`
+
+The GeoSPARQL dependency patch file (`docker/patches/enable-geosparql.diff`) is already applied by `docker/Dockerfile`; it does not need to be edited for normal version bumps.
+
+Then verify locally with:
+
+```
+task fuseki:smoke
+```
+
+The smoke test is deterministic and will fail fast if the image/runtime behaviour changes.
+
+### When you need a Jena source patch
+
+Only follow this path when you need behaviour that is not available in upstream Jena:
+
+- check out the target Jena tag from https://github.com/apache/jena (for example `git checkout jena-6.0.0`)
+- make your changes in Jena source
+- generate a patch with `git diff > my-patch.diff`
+- add the patch to `/docker/patches`
+- apply it from `docker/Dockerfile` in the builder stage (as done for `enable-geosparql.diff`)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,20 @@
 
 The image is available as `ghcr.io/kurrawong/fuseki:<version>` where version is composed of the jena version and this container image's build version number.
 
-For example, `ghcr.io/kurrawong/fuseki:5.2.0-0` is built on Jena Fuseki 5.2.0 and the `0` indicates the build number of this container image. If we release a new build that's still based on Jena 5.2.0, the build number will be incremented to 1 to form `ghcr.io/kurrawong/fuseki:5.2.0-1`.
+For example, `ghcr.io/kurrawong/fuseki:6.0.0-0` is built on Jena Fuseki 6.0.0 and the `0` indicates the build number of this container image. If we release a new build that's still based on Jena 6.0.0, the build number will be incremented to 1 to form `ghcr.io/kurrawong/fuseki:6.0.0-1`.
 
 See the tagged [images here](https://github.com/Kurrawong/fuseki-container-image/pkgs/container/fuseki).
+
+## Jena 6.0.0 migration notes
+
+- Minimum Java version is Java 21. This image now builds and runs on Java 21.
+- TDB2 data reload is recommended for existing datasets (especially if `xsd:decimal` values are used).
+- GeoSPARQL spatial indexes from Jena 5.x must be recreated because of the Kryo5 upgrade.
+  - Back up databases and indexes before migration.
+  - Delete or move old `spatial.index` files; missing indexes are rebuilt on startup.
+- `jena-text` now uses Lucene 10; rebuild Lucene indexes for existing datasets.
+- Removed modules in Jena 6 include `jena-iri`, `jena-fuseki-webapp`, `jena-fuseki-war`, and `jena-permissions`.
+- Package `org.apache.jena.tdb` was removed; use TDB2 or `org.apache.jena.tdb1` if needed.
 
 ## Usage
 
@@ -264,6 +275,6 @@ See [Taskfile.yml](Taskfile.yml) for local development commands.
 We can build patches for Jena ourselves by developing on a specific version of the Jena source code, and including patches in `/docker/patches`.
 A simple example of this is the addition of the GeoSPARQL dependency in `/docker/patches/enable-geosparql.diff` as inspired by the zazuko docker image.
 
-The process to add these to our own jena deployment is to check out the current Jena version tag from https://github.com/apache/jena , e.g. using `git checkout jena-5.2.0`
+The process to add these to our own jena deployment is to check out the current Jena version tag from https://github.com/apache/jena , e.g. using `git checkout jena-6.0.0`
 
 Then make the necessary changes, and run `git diff > my-patch.diff` and add `my-patch.diff` to `/docker/patches` and in the `Dockerfile`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ tasks:
     cmd: docker compose --profile fuseki down -v
 
   fuseki:smoke:run:
-    desc: Run GeoSPARQL and Lucene FTS smoke checks against an already-running Fuseki instance (supports optional spatial index delete + restart hooks)
+    desc: Run deterministic Fuseki smoke test (upload data, rebuild spatial index, assert queries)
     cmd: ./scripts/fuseki-smoke-test.sh
 
   fuseki:smoke:
@@ -32,7 +32,7 @@ tasks:
       - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki build
       - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki up -d
       - defer: docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v
-      - SMOKE_DELETE_SPATIAL_INDEX_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki exec -T fuseki sh -lc 'rm -f /fuseki/databases/test-geosparql/spatial.index'" SMOKE_RESTART_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki restart fuseki" task fuseki:smoke:run
+      - task fuseki:smoke:run
 
   fuseki:smoke:ci:
     desc: CI variant of smoke test with smoke config and quiet Docker build output, then clean up
@@ -41,4 +41,4 @@ tasks:
       - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki build -q
       - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki up -d
       - defer: docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v
-      - SMOKE_DELETE_SPATIAL_INDEX_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki exec -T fuseki sh -lc 'rm -f /fuseki/databases/test-geosparql/spatial.index'" SMOKE_RESTART_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki restart fuseki" task fuseki:smoke:run
+      - task fuseki:smoke:run

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,12 +22,23 @@ tasks:
     cmd: docker compose --profile fuseki down -v
 
   fuseki:smoke:run:
+    desc: Run the Fuseki smoke test against an already-running local instance
     cmd: ./scripts/fuseki-smoke-test.sh
 
   fuseki:smoke:
+    desc: Build and run Fuseki locally, execute smoke test, then clean up (verbose build logs)
     cmds:
       - docker compose --profile fuseki down -v || true
       - docker compose --profile fuseki build
+      - docker compose --profile fuseki up -d
+      - defer: docker compose --profile fuseki down -v
+      - task fuseki:smoke:run
+
+  fuseki:smoke:ci:
+    desc: CI variant of smoke test with quiet Docker build output, then clean up
+    cmds:
+      - docker compose --profile fuseki down -v || true
+      - docker compose --profile fuseki build -q
       - docker compose --profile fuseki up -d
       - defer: docker compose --profile fuseki down -v
       - task fuseki:smoke:run

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,23 +22,23 @@ tasks:
     cmd: docker compose --profile fuseki down -v
 
   fuseki:smoke:run:
-    desc: Run the Fuseki smoke test against an already-running local instance
+    desc: Run GeoSPARQL and Lucene FTS smoke checks against an already-running Fuseki instance (supports optional spatial index delete + restart hooks)
     cmd: ./scripts/fuseki-smoke-test.sh
 
   fuseki:smoke:
-    desc: Build and run Fuseki locally, execute smoke test, then clean up (verbose build logs)
+    desc: Build and run Fuseki with smoke config, execute smoke test, then clean up (verbose build logs)
     cmds:
-      - docker compose --profile fuseki down -v || true
-      - docker compose --profile fuseki build
-      - docker compose --profile fuseki up -d
-      - defer: docker compose --profile fuseki down -v
-      - task fuseki:smoke:run
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v || true
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki build
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki up -d
+      - defer: docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v
+      - SMOKE_DELETE_SPATIAL_INDEX_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki exec -T fuseki sh -lc 'rm -f /fuseki/databases/test-geosparql/spatial.index'" SMOKE_RESTART_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki restart fuseki" task fuseki:smoke:run
 
   fuseki:smoke:ci:
-    desc: CI variant of smoke test with quiet Docker build output, then clean up
+    desc: CI variant of smoke test with smoke config and quiet Docker build output, then clean up
     cmds:
-      - docker compose --profile fuseki down -v || true
-      - docker compose --profile fuseki build -q
-      - docker compose --profile fuseki up -d
-      - defer: docker compose --profile fuseki down -v
-      - task fuseki:smoke:run
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v || true
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki build -q
+      - docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki up -d
+      - defer: docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki down -v
+      - SMOKE_DELETE_SPATIAL_INDEX_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki exec -T fuseki sh -lc 'rm -f /fuseki/databases/test-geosparql/spatial.index'" SMOKE_RESTART_CMD="docker compose -f docker-compose.yml -f docker-compose.smoke.yml --profile fuseki restart fuseki" task fuseki:smoke:run

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,3 +20,14 @@ tasks:
 
   fuseki:clean:
     cmd: docker compose --profile fuseki down -v
+
+  fuseki:smoke:run:
+    cmd: ./scripts/fuseki-smoke-test.sh
+
+  fuseki:smoke:
+    cmds:
+      - docker compose --profile fuseki down -v || true
+      - docker compose --profile fuseki build
+      - docker compose --profile fuseki up -d
+      - defer: docker compose --profile fuseki down -v
+      - task fuseki:smoke:run

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,0 +1,4 @@
+services:
+  fuseki:
+    volumes:
+      - ./testdata/config-geosparql.ttl:/opt/fuseki/configuration/config-geosparql.ttl:ro

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG JENA_VERSION=5.5.0
+ARG JENA_VERSION=6.0.0
 ARG JENA_HOME="/opt/jena"
 ARG FUSEKI_HOME="/opt/fuseki"
 ARG FUSEKI_BASE="/fuseki"
@@ -7,7 +7,7 @@ ARG JAVA_OPTIONS="-Xmx2048m -Xms2048m"
 #
 # Builder
 #
-FROM maven:3-eclipse-temurin-17 AS builder
+FROM maven:3-eclipse-temurin-21 AS builder
 ARG JENA_VERSION
 ARG JENA_HOME
 ARG FUSEKI_HOME
@@ -66,7 +66,7 @@ RUN unzip "${JENA_BUILD_DIR}/jena/apache-jena/target/apache-jena-${JENA_VERSION}
 #
 # Final
 #
-FROM amazoncorretto:17-alpine3.19 AS final
+FROM amazoncorretto:21-alpine3.19 AS final
 ARG JENA_VERSION
 ENV JENA_VERSION=${JENA_VERSION}
 ARG JENA_HOME

--- a/docker/patches/enable-geosparql.diff
+++ b/docker/patches/enable-geosparql.diff
@@ -9,7 +9,7 @@ index ce2a979a6f..cf1cce2a6f 100644
 +    <dependency>
 +      <groupId>org.apache.jena</groupId>
 +      <artifactId>jena-geosparql</artifactId>
-+      <version>5.5.0</version>
++      <version>${project.version}</version>
 +    </dependency>
 +
      <dependency>

--- a/scripts/fuseki-smoke-test.sh
+++ b/scripts/fuseki-smoke-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_command curl
+require_command jq
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+FUSEKI_BASE_URL="${FUSEKI_BASE_URL:-http://localhost:3030}"
+SMOKE_DATASET="${SMOKE_DATASET:-test-geosparql}"
+SMOKE_DATA_FILE="${SMOKE_DATA_FILE:-${REPO_ROOT}/testdata/data-geosparql.ttl}"
+SMOKE_EXPECTED_COUNT="${SMOKE_EXPECTED_COUNT:-2}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-90}"
+
+if [[ ! -f "${SMOKE_DATA_FILE}" ]]; then
+  echo "Smoke test data file does not exist: ${SMOKE_DATA_FILE}" >&2
+  exit 1
+fi
+
+ping_url="${FUSEKI_BASE_URL}/\$/ping"
+datasets_url="${FUSEKI_BASE_URL}/\$/datasets"
+data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?default"
+query_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/sparql"
+
+echo "Waiting for Fuseki: ${ping_url}"
+deadline=$((SECONDS + SMOKE_TIMEOUT_SECONDS))
+until curl -fsS "${ping_url}" >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )); then
+    echo "Timed out after ${SMOKE_TIMEOUT_SECONDS}s waiting for Fuseki readiness" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+tmp_create="$(mktemp)"
+tmp_upload="$(mktemp)"
+tmp_query="$(mktemp)"
+cleanup() {
+  rm -f "${tmp_create}" "${tmp_upload}" "${tmp_query}"
+}
+trap cleanup EXIT
+
+echo "Creating dataset: ${SMOKE_DATASET}"
+create_status="$(
+  curl -sS -o "${tmp_create}" -w "%{http_code}" -X POST "${datasets_url}" \
+    -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" \
+    --data "dbName=${SMOKE_DATASET}&dbType=tdb2"
+)"
+if [[ "${create_status}" != "200" ]]; then
+  echo "Failed to create dataset (HTTP ${create_status})" >&2
+  cat "${tmp_create}" >&2
+  exit 1
+fi
+
+echo "Uploading data: ${SMOKE_DATA_FILE}"
+upload_status="$(
+  curl -sS -o "${tmp_upload}" -w "%{http_code}" -X POST "${data_url}" \
+    -H "Content-Type: text/turtle" \
+    --data-binary "@${SMOKE_DATA_FILE}"
+)"
+if [[ "${upload_status}" != "200" ]]; then
+  echo "Failed to upload smoke test data (HTTP ${upload_status})" >&2
+  cat "${tmp_upload}" >&2
+  exit 1
+fi
+
+SMOKE_QUERY="$(cat <<'EOF'
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+
+SELECT DISTINCT ?address
+WHERE {
+  BIND("POLYGON ((152.685242 -27.161808, 152.698975 -27.829361, 153.492737 -27.829361, 153.435059 -27.178912, 152.685242 -27.161808))"^^geo:wktLiteral AS ?polygon)
+  ?address geo:hasGeometry / geo:asWKT ?point .
+  FILTER(geof:sfWithin(?point, ?polygon))
+}
+EOF
+)"
+
+echo "Running README GeoSPARQL smoke query"
+query_status="$(
+  curl -sS -o "${tmp_query}" -w "%{http_code}" -G "${query_url}" \
+    --data-urlencode "query=${SMOKE_QUERY}" \
+    --data-urlencode "format=application/sparql-results+json"
+)"
+if [[ "${query_status}" != "200" ]]; then
+  echo "Smoke query failed (HTTP ${query_status})" >&2
+  cat "${tmp_query}" >&2
+  exit 1
+fi
+
+actual_count="$(jq -r '.results.bindings | length' "${tmp_query}")"
+if [[ "${actual_count}" != "${SMOKE_EXPECTED_COUNT}" ]]; then
+  echo "Unexpected smoke query result count. Expected ${SMOKE_EXPECTED_COUNT}, got ${actual_count}" >&2
+  cat "${tmp_query}" >&2
+  exit 1
+fi
+
+echo "Smoke test passed: query returned ${actual_count} result(s)"

--- a/scripts/fuseki-smoke-test.sh
+++ b/scripts/fuseki-smoke-test.sh
@@ -18,8 +18,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FUSEKI_BASE_URL="${FUSEKI_BASE_URL:-http://localhost:3030}"
 SMOKE_DATASET="${SMOKE_DATASET:-test-geosparql}"
 SMOKE_DATA_FILE="${SMOKE_DATA_FILE:-${REPO_ROOT}/testdata/data-geosparql.ttl}"
-SMOKE_EXPECTED_COUNT="${SMOKE_EXPECTED_COUNT:-2}"
+SMOKE_DATA_GRAPH="${SMOKE_DATA_GRAPH:-https://example.org/smoke-graph}"
+SMOKE_GEOSPARQL_EXPECTED_COUNT="${SMOKE_GEOSPARQL_EXPECTED_COUNT:-1}"
+SMOKE_FTS_EXPECTED_COUNT="${SMOKE_FTS_EXPECTED_COUNT:-2}"
+SMOKE_SPATIAL_INDEX_EXPECTED_COUNT="${SMOKE_SPATIAL_INDEX_EXPECTED_COUNT:-4}"
 SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-90}"
+SMOKE_DELETE_SPATIAL_INDEX_CMD="${SMOKE_DELETE_SPATIAL_INDEX_CMD:-}"
+SMOKE_RESTART_CMD="${SMOKE_RESTART_CMD:-}"
 
 if [[ ! -f "${SMOKE_DATA_FILE}" ]]; then
   echo "Smoke test data file does not exist: ${SMOKE_DATA_FILE}" >&2
@@ -28,84 +33,162 @@ fi
 
 ping_url="${FUSEKI_BASE_URL}/\$/ping"
 datasets_url="${FUSEKI_BASE_URL}/\$/datasets"
-data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?default"
 query_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/sparql"
+if [[ -n "${SMOKE_DATA_GRAPH}" ]]; then
+  data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?graph=${SMOKE_DATA_GRAPH}"
+else
+  data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?default"
+fi
 
-echo "Waiting for Fuseki: ${ping_url}"
-deadline=$((SECONDS + SMOKE_TIMEOUT_SECONDS))
-until curl -fsS "${ping_url}" >/dev/null 2>&1; do
-  if (( SECONDS >= deadline )); then
-    echo "Timed out after ${SMOKE_TIMEOUT_SECONDS}s waiting for Fuseki readiness" >&2
-    exit 1
-  fi
-  sleep 1
-done
+wait_for_fuseki() {
+  echo "Waiting for Fuseki: ${ping_url}"
+  local deadline
+  deadline=$((SECONDS + SMOKE_TIMEOUT_SECONDS))
+
+  until curl -fsS "${ping_url}" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "Timed out after ${SMOKE_TIMEOUT_SECONDS}s waiting for Fuseki readiness" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_fuseki
 
 tmp_create="$(mktemp)"
+tmp_datasets="$(mktemp)"
 tmp_upload="$(mktemp)"
-tmp_query="$(mktemp)"
+tmp_query_geosparql="$(mktemp)"
+tmp_query_fts="$(mktemp)"
+tmp_query_spatial_index="$(mktemp)"
 cleanup() {
-  rm -f "${tmp_create}" "${tmp_upload}" "${tmp_query}"
+  rm -f "${tmp_create}" "${tmp_datasets}" "${tmp_upload}" "${tmp_query_geosparql}" "${tmp_query_fts}" "${tmp_query_spatial_index}"
 }
 trap cleanup EXIT
 
-echo "Creating dataset: ${SMOKE_DATASET}"
-create_status="$(
-  curl -sS -o "${tmp_create}" -w "%{http_code}" -X POST "${datasets_url}" \
-    -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" \
-    --data "dbName=${SMOKE_DATASET}&dbType=tdb2"
+datasets_status="$(
+  curl -sS -o "${tmp_datasets}" -w "%{http_code}" "${datasets_url}"
 )"
-if [[ "${create_status}" != "200" ]]; then
-  echo "Failed to create dataset (HTTP ${create_status})" >&2
-  cat "${tmp_create}" >&2
+if [[ "${datasets_status}" != "200" ]]; then
+  echo "Failed to list datasets (HTTP ${datasets_status})" >&2
+  cat "${tmp_datasets}" >&2
+  exit 1
+fi
+
+if jq -e --arg ds "/${SMOKE_DATASET}" '.datasets[]? | select(."ds.name" == $ds)' "${tmp_datasets}" >/dev/null; then
+  echo "Dataset configured: ${SMOKE_DATASET}"
+else
+  echo "Expected dataset '/${SMOKE_DATASET}' is missing. Smoke tests require preconfigured dataset setup." >&2
+  cat "${tmp_datasets}" >&2
   exit 1
 fi
 
 echo "Uploading data: ${SMOKE_DATA_FILE}"
+if [[ -n "${SMOKE_DATA_GRAPH}" ]]; then
+  echo "Target graph: ${SMOKE_DATA_GRAPH}"
+else
+  echo "Target graph: default"
+fi
 upload_status="$(
   curl -sS -o "${tmp_upload}" -w "%{http_code}" -X POST "${data_url}" \
     -H "Content-Type: text/turtle" \
     --data-binary "@${SMOKE_DATA_FILE}"
 )"
-if [[ "${upload_status}" != "200" ]]; then
+if [[ "${upload_status}" != "200" && "${upload_status}" != "201" && "${upload_status}" != "204" ]]; then
   echo "Failed to upload smoke test data (HTTP ${upload_status})" >&2
   cat "${tmp_upload}" >&2
   exit 1
 fi
 
-SMOKE_QUERY="$(cat <<'EOF'
+if [[ -n "${SMOKE_DELETE_SPATIAL_INDEX_CMD}" ]]; then
+  echo "Deleting spatial index file before restart"
+  bash -lc "${SMOKE_DELETE_SPATIAL_INDEX_CMD}"
+fi
+
+if [[ -n "${SMOKE_RESTART_CMD}" ]]; then
+  echo "Restarting Fuseki to trigger spatial index creation"
+  bash -lc "${SMOKE_RESTART_CMD}"
+  wait_for_fuseki
+fi
+
+run_query_and_assert() {
+  local label="$1"
+  local query="$2"
+  local expected_count="$3"
+  local output_file="$4"
+
+  local status
+  status="$(
+    curl -sS -o "${output_file}" -w "%{http_code}" -G "${query_url}" \
+      --data-urlencode "query=${query}" \
+      --data-urlencode "format=application/sparql-results+json"
+  )"
+
+  if [[ "${status}" != "200" ]]; then
+    echo "${label} failed (HTTP ${status})" >&2
+    cat "${output_file}" >&2
+    exit 1
+  fi
+
+  echo "${label} response:"
+  jq . "${output_file}"
+
+  local actual_count
+  actual_count="$(jq -r '.results.bindings | length' "${output_file}")"
+  if [[ "${actual_count}" != "${expected_count}" ]]; then
+    echo "${label} returned unexpected result count. Expected ${expected_count}, got ${actual_count}" >&2
+    cat "${output_file}" >&2
+    exit 1
+  fi
+}
+
+SMOKE_GEOSPARQL_QUERY="$(cat <<'EOF'
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 
-SELECT DISTINCT ?address
+SELECT (COUNT(*) AS ?count)
 WHERE {
+  BIND("POINT (153.13401606 -27.62096167)"^^geo:wktLiteral AS ?point)
   BIND("POLYGON ((152.685242 -27.161808, 152.698975 -27.829361, 153.492737 -27.829361, 153.435059 -27.178912, 152.685242 -27.161808))"^^geo:wktLiteral AS ?polygon)
-  ?address geo:hasGeometry / geo:asWKT ?point .
   FILTER(geof:sfWithin(?point, ?polygon))
 }
 EOF
 )"
 
-echo "Running README GeoSPARQL smoke query"
-query_status="$(
-  curl -sS -o "${tmp_query}" -w "%{http_code}" -G "${query_url}" \
-    --data-urlencode "query=${SMOKE_QUERY}" \
-    --data-urlencode "format=application/sparql-results+json"
+SMOKE_FTS_QUERY="$(cat <<'EOF'
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX text: <http://jena.apache.org/text#>
+
+SELECT DISTINCT ?address ?literal
+WHERE {
+  (?address ?score ?literal) text:query ( rdfs:label "Drive" ) .
+}
+EOF
 )"
-if [[ "${query_status}" != "200" ]]; then
-  echo "Smoke query failed (HTTP ${query_status})" >&2
-  cat "${tmp_query}" >&2
-  exit 1
-fi
 
-echo "Smoke query response:"
-jq . "${tmp_query}"
+SMOKE_SPATIAL_INDEX_QUERY="$(cat <<'EOF'
+PREFIX addr: <https://linked.data.gov.au/def/addr/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-actual_count="$(jq -r '.results.bindings | length' "${tmp_query}")"
-if [[ "${actual_count}" != "${SMOKE_EXPECTED_COUNT}" ]]; then
-  echo "Unexpected smoke query result count. Expected ${SMOKE_EXPECTED_COUNT}, got ${actual_count}" >&2
-  cat "${tmp_query}" >&2
-  exit 1
-fi
+SELECT ?addr ?label
+WHERE {
+  ?addr a addr:Address ;
+        rdfs:label ?label .
+  ?addr geo:sfWithin <https://example.org/australia> .
+}
+ORDER BY ?label
+EOF
+)"
 
-echo "Smoke test passed: query returned ${actual_count} result(s)"
+echo "Running README GeoSPARQL smoke query"
+run_query_and_assert "GeoSPARQL smoke query" "${SMOKE_GEOSPARQL_QUERY}" "${SMOKE_GEOSPARQL_EXPECTED_COUNT}" "${tmp_query_geosparql}"
+
+echo "Running README Lucene FTS smoke query"
+run_query_and_assert "Lucene FTS smoke query" "${SMOKE_FTS_QUERY}" "${SMOKE_FTS_EXPECTED_COUNT}" "${tmp_query_fts}"
+
+echo "Running spatial index smoke query"
+run_query_and_assert "Spatial index smoke query" "${SMOKE_SPATIAL_INDEX_QUERY}" "${SMOKE_SPATIAL_INDEX_EXPECTED_COUNT}" "${tmp_query_spatial_index}"
+
+echo "Smoke test passed: GeoSPARQL, Lucene FTS, and spatial index queries returned expected results"

--- a/scripts/fuseki-smoke-test.sh
+++ b/scripts/fuseki-smoke-test.sh
@@ -98,6 +98,9 @@ if [[ "${query_status}" != "200" ]]; then
   exit 1
 fi
 
+echo "Smoke query response:"
+jq . "${tmp_query}"
+
 actual_count="$(jq -r '.results.bindings | length' "${tmp_query}")"
 if [[ "${actual_count}" != "${SMOKE_EXPECTED_COUNT}" ]]; then
   echo "Unexpected smoke query result count. Expected ${SMOKE_EXPECTED_COUNT}, got ${actual_count}" >&2

--- a/scripts/fuseki-smoke-test.sh
+++ b/scripts/fuseki-smoke-test.sh
@@ -11,20 +11,27 @@ require_command() {
 
 require_command curl
 require_command jq
+require_command docker
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-FUSEKI_BASE_URL="${FUSEKI_BASE_URL:-http://localhost:3030}"
-SMOKE_DATASET="${SMOKE_DATASET:-test-geosparql}"
-SMOKE_DATA_FILE="${SMOKE_DATA_FILE:-${REPO_ROOT}/testdata/data-geosparql.ttl}"
-SMOKE_DATA_GRAPH="${SMOKE_DATA_GRAPH:-https://example.org/smoke-graph}"
-SMOKE_GEOSPARQL_EXPECTED_COUNT="${SMOKE_GEOSPARQL_EXPECTED_COUNT:-1}"
-SMOKE_FTS_EXPECTED_COUNT="${SMOKE_FTS_EXPECTED_COUNT:-2}"
-SMOKE_SPATIAL_INDEX_EXPECTED_COUNT="${SMOKE_SPATIAL_INDEX_EXPECTED_COUNT:-4}"
-SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-90}"
-SMOKE_DELETE_SPATIAL_INDEX_CMD="${SMOKE_DELETE_SPATIAL_INDEX_CMD:-}"
-SMOKE_RESTART_CMD="${SMOKE_RESTART_CMD:-}"
+FUSEKI_BASE_URL="http://localhost:3030"
+SMOKE_DATASET="test-geosparql"
+SMOKE_DATA_FILE="${REPO_ROOT}/testdata/data-geosparql.ttl"
+SMOKE_DATA_GRAPH="https://example.org/smoke-graph"
+SMOKE_GEOSPARQL_EXPECTED_COUNT="1"
+SMOKE_FTS_EXPECTED_COUNT="2"
+SMOKE_SPATIAL_INDEX_EXPECTED_COUNT="4"
+SMOKE_TIMEOUT_SECONDS="90"
+SPATIAL_INDEX_FILE="/fuseki/databases/test-geosparql/spatial.index"
+
+SMOKE_COMPOSE=(
+  docker compose
+  -f docker-compose.yml
+  -f docker-compose.smoke.yml
+  --profile fuseki
+)
 
 if [[ ! -f "${SMOKE_DATA_FILE}" ]]; then
   echo "Smoke test data file does not exist: ${SMOKE_DATA_FILE}" >&2
@@ -34,11 +41,7 @@ fi
 ping_url="${FUSEKI_BASE_URL}/\$/ping"
 datasets_url="${FUSEKI_BASE_URL}/\$/datasets"
 query_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/sparql"
-if [[ -n "${SMOKE_DATA_GRAPH}" ]]; then
-  data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?graph=${SMOKE_DATA_GRAPH}"
-else
-  data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?default"
-fi
+data_url="${FUSEKI_BASE_URL}/${SMOKE_DATASET}/data?graph=${SMOKE_DATA_GRAPH}"
 
 wait_for_fuseki() {
   echo "Waiting for Fuseki: ${ping_url}"
@@ -56,14 +59,13 @@ wait_for_fuseki() {
 
 wait_for_fuseki
 
-tmp_create="$(mktemp)"
 tmp_datasets="$(mktemp)"
 tmp_upload="$(mktemp)"
 tmp_query_geosparql="$(mktemp)"
 tmp_query_fts="$(mktemp)"
 tmp_query_spatial_index="$(mktemp)"
 cleanup() {
-  rm -f "${tmp_create}" "${tmp_datasets}" "${tmp_upload}" "${tmp_query_geosparql}" "${tmp_query_fts}" "${tmp_query_spatial_index}"
+  rm -f "${tmp_datasets}" "${tmp_upload}" "${tmp_query_geosparql}" "${tmp_query_fts}" "${tmp_query_spatial_index}"
 }
 trap cleanup EXIT
 
@@ -85,11 +87,7 @@ else
 fi
 
 echo "Uploading data: ${SMOKE_DATA_FILE}"
-if [[ -n "${SMOKE_DATA_GRAPH}" ]]; then
-  echo "Target graph: ${SMOKE_DATA_GRAPH}"
-else
-  echo "Target graph: default"
-fi
+echo "Target graph: ${SMOKE_DATA_GRAPH}"
 upload_status="$(
   curl -sS -o "${tmp_upload}" -w "%{http_code}" -X POST "${data_url}" \
     -H "Content-Type: text/turtle" \
@@ -101,16 +99,12 @@ if [[ "${upload_status}" != "200" && "${upload_status}" != "201" && "${upload_st
   exit 1
 fi
 
-if [[ -n "${SMOKE_DELETE_SPATIAL_INDEX_CMD}" ]]; then
-  echo "Deleting spatial index file before restart"
-  bash -lc "${SMOKE_DELETE_SPATIAL_INDEX_CMD}"
-fi
+echo "Deleting spatial index file before restart: ${SPATIAL_INDEX_FILE}"
+"${SMOKE_COMPOSE[@]}" exec -T fuseki sh -lc "rm -f ${SPATIAL_INDEX_FILE}"
 
-if [[ -n "${SMOKE_RESTART_CMD}" ]]; then
-  echo "Restarting Fuseki to trigger spatial index creation"
-  bash -lc "${SMOKE_RESTART_CMD}"
-  wait_for_fuseki
-fi
+echo "Restarting Fuseki to trigger spatial index creation"
+"${SMOKE_COMPOSE[@]}" restart fuseki
+wait_for_fuseki
 
 run_query_and_assert() {
   local label="$1"


### PR DESCRIPTION
This PR updates build/runtime, keeps smoke validation consistent across local and CI/release, and documents migration expectations clearly.

Jena 6 introduces breaking platform/runtime and migration changes (notably Java 21 and index/data migration concerns). See Jena changelog for more details: https://github.com/apache/jena/blob/main/CHANGES.txt.

- Upgraded Jena version in build defaults:
    - JENA_VERSION from 5.5.0 to 6.0.0
- Upgraded Java runtime/build baseline to Java 21
- Fixed GeoSPARQL patch versioning:
    - docker/patches/enable-geosparql.diff now uses ${project.version} instead of hardcoding
- Added and integrated smoke testing:
    - Reusable smoke script that creates a dataset, uploads sample data, runs README GeoSPARQL query, and asserts expected results