### PR TITLE
build: upgrade to alpine 3.23

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ RUN unzip "${JENA_BUILD_DIR}/jena/apache-jena/target/apache-jena-${JENA_VERSION}
 #
 # Final
 #
-FROM amazoncorretto:21-alpine3.19 AS final
+FROM amazoncorretto:21-alpine3.23 AS final
 ARG JENA_VERSION
 ENV JENA_VERSION=${JENA_VERSION}
 ARG JENA_HOME


### PR DESCRIPTION
Alpine 3.19 is EOL. This PR upgrades the base runtime image to Alpine 3.23.

This addresses the high-severity vulnerabilities in the Alpine image, but does not address the vulnerabilities in Jena. Those will need to be fixed upstream.

```
Java (jar)

Total: 13 (UNKNOWN: 0, LOW: 2, MEDIUM: 8, HIGH: 3, CRITICAL: 0)

┌─────────────────────────────────────────────────────────────┬────────────────┬──────────┬──────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                           │ Vulnerability  │ Severity │  Status  │ Installed Version │  Fixed Version  │                            Title                            │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼──────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.apache.logging.log4j:log4j-core (fuseki-server.jar)     │ CVE-2025-68161 │ MEDIUM   │ fixed    │ 2.25.2            │ 2.25.3          │ The Socket Appender in Apache Log4j Core versions 2.0-beta9 │
│                                                             │                │          │          │                   │                 │ through 2. ......                                           │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-68161                  │
├─────────────────────────────────────────────────────────────┤                │          │          │                   │                 │                                                             │
│ org.apache.logging.log4j:log4j-core (log4j-core-2.25.2.jar) │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
├─────────────────────────────────────────────────────────────┼────────────────┤          │          │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.apache.logging.log4j:log4j-core (fuseki-server.jar)     │ CVE-2026-34477 │          │          │                   │ 2.25.4          │ org.apache.logging.log4j/log4j-core: Apache Log4j Core:     │
│                                                             │                │          │          │                   │                 │ Man-in-the-middle attack due to incomplete hostname         │
│                                                             │                │          │          │                   │                 │ verification                                                │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-34477                  │
├─────────────────────────────────────────────────────────────┤                │          │          │                   │                 │                                                             │
│ org.apache.logging.log4j:log4j-core (log4j-core-2.25.2.jar) │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
├─────────────────────────────────────────────────────────────┼────────────────┤          │          │                   │                 ├─────────────────────────────────────────────────────────────┤
│ org.apache.logging.log4j:log4j-core (fuseki-server.jar)     │ CVE-2026-34478 │          │          │                   │                 │ org.apache.logging.log4j/log4j-core: Apache Log4j Core: Log │
│                                                             │                │          │          │                   │                 │ injection via CRLF sequences due to configuration...        │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-34478                  │
├─────────────────────────────────────────────────────────────┤                │          │          │                   │                 │                                                             │
│ org.apache.logging.log4j:log4j-core (log4j-core-2.25.2.jar) │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
├─────────────────────────────────────────────────────────────┼────────────────┤          │          │                   │                 ├─────────────────────────────────────────────────────────────┤
│ org.apache.logging.log4j:log4j-core (fuseki-server.jar)     │ CVE-2026-34480 │          │          │                   │                 │ org.apache.logging.log4j/log4j-core: Apache Log4j Core:     │
│                                                             │                │          │          │                   │                 │ Invalid XML output causes denial of service in...           │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-34480                  │
├─────────────────────────────────────────────────────────────┤                │          │          │                   │                 │                                                             │
│ org.apache.logging.log4j:log4j-core (log4j-core-2.25.2.jar) │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
│                                                             │                │          │          │                   │                 │                                                             │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┤          ├───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.apache.shiro:shiro-core (fuseki-server.jar)             │ CVE-2026-23901 │ LOW      │          │ 2.0.5             │ 2.1.0           │ org.apache.shiro/shiro-core: Apache Shiro: Brute force      │
│                                                             │                │          │          │                   │                 │ attack possible to determine valid user names...            │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-23901                  │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼──────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.apache.thrift:libthrift (libthrift-0.22.0.jar)          │ CVE-2026-43869 │ HIGH     │ affected │ 0.22.0            │                 │ Improper Validation of Certificate with Host Mismatch       │
│                                                             │                │          │          │                   │                 │ vulnerability in ...                                        │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-43869                  │
├─────────────────────────────────────────────────────────────┼────────────────┤          ├──────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-http (fuseki-server.jar)            │ CVE-2026-2332  │          │ fixed    │ 12.1.1            │ 12.1.7, 12.0.33 │ org.eclipse.jetty/jetty-http: HTTP request smuggling via    │
│                                                             │                │          │          │                   │                 │ chunked extension quoted-string parsing                     │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-2332                   │
│                                                             ├────────────────┼──────────┤          │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│                                                             │ CVE-2025-11143 │ LOW      │          │                   │ 12.0.31, 12.1.5 │ org.eclipse.jetty/jetty-http: org.eclipse.jetty: Security   │
│                                                             │                │          │          │                   │                 │ bypass due to differential URI parsing                      │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-11143                  │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┤          │                   ├─────────────────┼─────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-server (fuseki-server.jar)          │ CVE-2026-1605  │ HIGH     │          │                   │ 12.1.6, 12.0.32 │ org.eclipse.jetty/jetty-server: Eclipse Jetty: Denial of    │
│                                                             │                │          │          │                   │                 │ Service due to unreleased JDK Inflater from...              │
│                                                             │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-1605                   │
└─────────────────────────────────────────────────────────────┴────────────────┴──────────┴──────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```